### PR TITLE
Update to support the latest game features

### DIFF
--- a/Models/ArmyNames.cs
+++ b/Models/ArmyNames.cs
@@ -18,6 +18,8 @@ namespace StellarisNameListGenerator.Models
         public List<NameGroup> SlaveArmy { get; set; }
         public string CloneArmySequentialName { get; set; }
         public List<NameGroup> CloneArmy { get; set; }
+        public string UndeadArmySequentialName { get; set; }
+        public List<NameGroup> UndeadArmy { get; set; }
         
         public string RoboticDefenceArmySequentialName { get; set; }
         public List<NameGroup> RoboticDefenceArmy { get; set; }

--- a/Service/NamesBuilders/ArmyNamesBuilder.cs
+++ b/Service/NamesBuilders/ArmyNamesBuilder.cs
@@ -8,12 +8,57 @@ namespace StellarisNameListGenerator.Service.NamesBuilders
 {
     public sealed class ArmyNamesBuilder : NamesBuilder, IArmyNamesBuilder
     {
+        static readonly List<NameGroup> EmptyNameList = new List<NameGroup>(); // TODO: Temporary solution. Remove this
+
         public string Build(NameList nameList)
         {
-            string content = string.Empty;
+            string content = $"{GetIndentation(1)}army_names = {{{Environment.NewLine}";
             
-            content += $"{GetIndentation(1)}army_names = {{{Environment.NewLine}";
+            IEnumerable<NameGroup> psionicArmies = GeneratePsionicArmyNames(nameList);
+            IEnumerable<NameGroup> xenomorphArmies = GenerateXenomorphArmyNames(nameList);
 
+            string innerContent = string.Empty;
+            
+            innerContent += BuildNameArray(EmptyNameList, "machine_defense", 2, nameList.Armies.DefenceArmySequentialName);
+            innerContent += BuildNameArray(EmptyNameList, "machine_assault_1", 2, nameList.Armies.AssaultArmySequentialName);
+            innerContent += BuildNameArray(EmptyNameList, "machine_assault_2", 2, nameList.Armies.AssaultArmySequentialName);
+            innerContent += BuildNameArray(EmptyNameList, "machine_assault_3", 2, nameList.Armies.AssaultArmySequentialName);
+
+            innerContent += BuildNameArray(nameList.Armies.DefenceArmy, "defense_army", 2, nameList.Armies.DefenceArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.AssaultArmy, "assault_army", 2, nameList.Armies.AssaultArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.OccupationArmy, "occupation_army", 2, nameList.Armies.OccupationArmySequentialName);
+
+            innerContent += BuildNameArray(nameList.Armies.SlaveArmy, "slave_army", 2, nameList.Armies.SlaveArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.CloneArmy, "clone_army", 2, nameList.Armies.CloneArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.UndeadArmy, "undead_army", 2, nameList.Armies.UndeadArmySequentialName);
+
+            innerContent += BuildNameArray(nameList.Armies.RoboticDefenceArmy, "robotic_defense_army", 2, nameList.Armies.RoboticDefenceArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.RoboticAssaultArmy, "robotic_army", 2, nameList.Armies.RoboticAssaultArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.RoboticOccupationArmy, "robotic_occupation_army", 2, nameList.Armies.RoboticOccupationArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.AndroidDefenceArmy, "android_defense_army", 2, nameList.Armies.AndroidDefenceArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.AndroidAssaultArmy, "android_army", 2, nameList.Armies.AndroidAssaultArmySequentialName);
+
+            innerContent += BuildNameArray(psionicArmies, "psionic_army", 2, nameList.Armies.PsionicArmySequentialName);
+            innerContent += BuildNameArray(xenomorphArmies, "xenomorph_army", 2, nameList.Armies.XenomorphArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.SuperSoldierArmy, "gene_warrior_army", 2, nameList.Armies.SuperSoldierArmySequentialName);
+
+            innerContent += BuildNameArray(nameList.Armies.PrimitiveArmy, "primitive_army", 2, nameList.Armies.PrimitiveArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.IndustrialArmy, "industrial_army", 2, nameList.Armies.IndustrialArmySequentialName);
+            innerContent += BuildNameArray(nameList.Armies.PostAtomicArmy, "postatomic_army", 2, nameList.Armies.PostAtomicArmySequentialName);
+
+            if (string.IsNullOrWhiteSpace(innerContent))
+            {
+                return string.Empty;
+            }
+
+            content += innerContent;
+            content += $"{GetIndentation(1)}}}{Environment.NewLine}";
+
+            return content;
+        }
+
+        IEnumerable<NameGroup> GeneratePsionicArmyNames(NameList nameList)
+        {
             IEnumerable<NameGroup> psionicArmyNames = nameList.Armies.PsionicArmy
                 .Concat(nameList.BiosphereNames.MythologicalCreatures
                     .SelectMany(x => new List<NameGroup>
@@ -24,6 +69,11 @@ namespace StellarisNameListGenerator.Service.NamesBuilders
                         new NameGroup { Name = $"Squadrons - Mythological creatures", ExplicitValues = x.Values.Select(y => $"{y} Squadron").ToList() },
                     }));
 
+            return psionicArmyNames;
+        }
+
+        IEnumerable<NameGroup> GenerateXenomorphArmyNames(NameList nameList)
+        {
             IList<NameGroup> xenomorphArmies = nameList.Armies.XenomorphArmy;
             IEnumerable<NameGroup> deitiesForXenomorph = nameList.GreatPeople.DeathDeities
                 .Concat(nameList.GreatPeople.HatredDeities)
@@ -48,30 +98,7 @@ namespace StellarisNameListGenerator.Service.NamesBuilders
             xenomorphArmies.Add(GenerateUnifiedNameGroup(deitiesForXenomorph, "Xenomorph Swarms", "Deities", "{0}'s Xenomorph Swarm"));
             xenomorphArmies.Add(GenerateUnifiedNameGroup(deitiesForXenomorph, "Xenomorph Troopers", "Deities", "{0}'s Xenomorph Troopers"));
 
-            string innerContent = string.Empty;
-            innerContent += BuildNameArray(nameList.Armies.DefenceArmy, "defense_army", 2, nameList.Armies.DefenceArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.AssaultArmy, "assault_army", 2, nameList.Armies.AssaultArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.OccupationArmy, "occupation_army", 2, nameList.Armies.OccupationArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.SlaveArmy, "slave_army", 2, nameList.Armies.SlaveArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.CloneArmy, "clone_army", 2, nameList.Armies.CloneArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.RoboticDefenceArmy, "robotic_defense_army", 2, nameList.Armies.RoboticDefenceArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.RoboticAssaultArmy, "robotic_army", 2, nameList.Armies.RoboticAssaultArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.RoboticOccupationArmy, "robotic_occupation_army", 2, nameList.Armies.RoboticOccupationArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.AndroidDefenceArmy, "android_defense_army", 2, nameList.Armies.AndroidDefenceArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.AndroidAssaultArmy, "android_army", 2, nameList.Armies.AndroidAssaultArmySequentialName);
-            innerContent += BuildNameArray(psionicArmyNames, "psionic_army", 2, nameList.Armies.PsionicArmySequentialName);
-            innerContent += BuildNameArray(xenomorphArmies, "xenomorph_army", 2, nameList.Armies.XenomorphArmySequentialName);
-            innerContent += BuildNameArray(nameList.Armies.SuperSoldierArmy, "gene_warrior_army", 2, nameList.Armies.SuperSoldierArmySequentialName);
-
-            if (string.IsNullOrWhiteSpace(innerContent))
-            {
-                return string.Empty;
-            }
-
-            content += innerContent;
-            content += $"{GetIndentation(1)}}}{Environment.NewLine}";
-
-            return content;
+            return xenomorphArmies;
         }
     }
 }

--- a/Service/NamesBuilders/FleetNamesBuilder.cs
+++ b/Service/NamesBuilders/FleetNamesBuilder.cs
@@ -52,7 +52,7 @@ namespace StellarisNameListGenerator.Service.NamesBuilders
                 .Concat(GenerateFleetNamesCategory(nameList, "Squadrons", "{0} Squadron"))
                 .Concat(GenerateFleetNamesCategory(nameList, "Starfleets", "{0} Starfleet"))
                 .Concat(GenerateFleetNamesCategory(nameList, "Strike Forces", "Strike Force {0}"))
-                .Concat(GenerateFleetNamesCategory(nameList, "Strike Teams", "Strike Teams {0}"))
+                .Concat(GenerateFleetNamesCategory(nameList, "Strike Teams", "Strike Team {0}"))
                 .Concat(GenerateFleetNamesCategory(nameList, "Task Forces", "Task Force {0}"))
                 .ToList();
         }

--- a/package.sh
+++ b/package.sh
@@ -36,17 +36,7 @@ function dotnet-pub {
     dotnet publish -c Release -r "$ARCH" -o "$OUTPUT_DIR" --self-contained=true /p:TrimUnusedDependencies=true /p:LinkDuringPublish=true
 }
 
-function prepare {
-    echo "Adding the temporary NuGet packages"
-    dotnet add package Microsoft.Packaging.Tools.Trimming --version 1.1.0-preview1-26619-01
-    #dotnet add package ILLink.Tasks --version 0.1.5-preview-1841731 --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
-}
-
 function cleanup {
-    echo "Removing the temporary NuGet packages"
-    dotnet remove package Microsoft.Packaging.Tools.Trimming
-    #dotnet remove package ILLink.Task
-
     echo "Cleaning build output"
     rm -rf "$PUBLISH_DIR"
 }
@@ -55,8 +45,6 @@ function build-release {
     dotnet-pub $1
     package $1
 }
-
-prepare
 
 build-release linux-arm
 build-release linux-arm64


### PR DESCRIPTION
 - Added support for Undead Army names
 - Added placeholders for Machine Army names _(**1**)_
 - Fixed a typo in some fleet names _(**2**)_
 - Removed the trimming NuGet package from the packaging script

_(**1**)_: The names are taken from Assault Army and Defence Army respectively and cannot yet be customised
_(**2**)_: Fixed "Strike Team XYZ" mistakenly being in plural form ("Strike Teams XYZ")