### PR TITLE
Fixes

### DIFF
--- a/Models/ArmyNames.cs
+++ b/Models/ArmyNames.cs
@@ -87,9 +87,9 @@ namespace StellarisNameListGenerator.Models
 
             PrimitiveArmySequentialName = "Primitive Army %C%";
             PrimitiveArmy = new List<NameGroup>();
-            IndustrialArmySequentialName = "Primitive Army %C%";
+            IndustrialArmySequentialName = "Industrial Army %C%";
             IndustrialArmy = new List<NameGroup>();
-            PostAtomicArmySequentialName = "Primitive Army %C%";
+            PostAtomicArmySequentialName = "Post-Atomic Army %C%";
             PostAtomicArmy = new List<NameGroup>();
         }
     }

--- a/Models/ArmyNames.cs
+++ b/Models/ArmyNames.cs
@@ -63,6 +63,8 @@ namespace StellarisNameListGenerator.Models
             SlaveArmy = new List<NameGroup>();
             CloneArmySequentialName = "%O% Clone Army";
             CloneArmy = new List<NameGroup>();
+            UndeadArmySequentialName = "%O% Undead Army";
+            UndeadArmy = new List<NameGroup>();
 
             RoboticDefenceArmySequentialName = "%O% Ground Defence Matrix";
             RoboticDefenceArmy = new List<NameGroup>();


### PR DESCRIPTION
 - Fixed Undead Army names not being assigned _(**1**)_
 - Fixed the default sequencial names for the Industrial and Post-Atomic armies

_(**1**)_: The bug resulted in the whole application crashing